### PR TITLE
make bop_toolkit_lib installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Python toolkit of the BOP benchmark for 6D object pose estimation
 
 To install the required python libraries, run:
 ```
-pip install -r requirements.txt
+pip install -r requirements.txt -e .
 ```
 
 In the case of problems, try to first run: ```pip install --upgrade pip setuptools```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='bop_toolkit_lib',
+    version='1.0',
+    packages=find_packages(exclude=('docs')),
+    install_requires=[],
+    author='Tomas Hodan, Martin Sundermeyer',
+    author_email='tom.hodan@gmail.com, Martin.Sundermeyer@dlr.de',
+    license='MIT license',
+    package_data={'bop_toolkit_lib':['*']},
+)


### PR DESCRIPTION
Lets users install `bop_toolkit_lib` in an editable way. 

Advantages:

- Scripts can be called outside of the git repo
- Utility functions can be called outside of the git repo
- No manual sys path additions are necessary
- Users can still edit `config.py` and other files without reinstalling the library