### PR TITLE
Fix missing identity in get_symmetry_transformations

### DIFF
--- a/bop_toolkit_lib/misc.py
+++ b/bop_toolkit_lib/misc.py
@@ -71,7 +71,7 @@ def get_symmetry_transformations(model_info, max_sym_disc_step):
       # Discrete step in radians.
       discrete_step = 2.0 * np.pi / discrete_steps_count
 
-      for i in range(1, discrete_steps_count):
+      for i in range(0, discrete_steps_count):
         R = transform.rotation_matrix(i * discrete_step, axis)[:3, :3]
         t = -R.dot(offset) + offset
         trans_cont.append({'R': R, 't': t})


### PR DESCRIPTION
Without this fix, the identity transformation is only included for the discrete transformations, but missing from the continuous transformations:

```python
>>> import json
>>> from bop_toolkit_lib.misc import get_symmetry_transformations
>>> from numpy import pi

 # before this PR:
>>> model_info_discrete = json.loads('{ "symmetries_discrete": [[-1,  0,  0,  0, 0, -1,  0,  0, 0,  0,  1,  0, 0,  0,  0,  1]] }')
>>> get_symmetry_transformations(model_info_discrete, pi / 4)
[{'R': array([[1., 0., 0.],
         [0., 1., 0.],
         [0., 0., 1.]]),
  't': array([[0],
         [0],
         [0]])},
 {'R': array([[-1,  0,  0],
         [ 0, -1,  0],
         [ 0,  0,  1]]),
  't': array([[0],
         [0],
         [0]])}]

>>> model_info_continuous = json.loads('{ "symmetries_continuous": [{"axis": [1, 0, 0], "offset": [0, 0, 0]}] }')
>>> get_symmetry_transformations(model_info_continuous, pi / 4)
[{'R': array([[ 1.000000e+00,  0.000000e+00,  0.000000e+00],
         [ 0.000000e+00,  6.123234e-17, -1.000000e+00],
         [ 0.000000e+00,  1.000000e+00,  6.123234e-17]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.0000000e+00,  0.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00, -1.0000000e+00, -1.2246468e-16],
         [ 0.0000000e+00,  1.2246468e-16, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.0000000e+00,  0.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00, -1.8369702e-16,  1.0000000e+00],
         [ 0.0000000e+00, -1.0000000e+00, -1.8369702e-16]]),
  't': array([[0.],
         [0.],
         [0.]])}]

>>> model_info_both = json.loads('{ "symmetries_discrete": [[1,  0,  0,  0, 0, -1,  0,  0, 0,  0, -1,  0, 0,  0, 0,   1]], "symmetries_continuous": [{"axis": [0, 0, 1], "offset": [0, 0, 0]}] }')
>>> get_symmetry_transformations(model_info_both, pi / 4)
[{'R': array([[ 6.123234e-17, -1.000000e+00,  0.000000e+00],
         [ 1.000000e+00,  6.123234e-17,  0.000000e+00],
         [ 0.000000e+00,  0.000000e+00,  1.000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.0000000e+00, -1.2246468e-16,  0.0000000e+00],
         [ 1.2246468e-16, -1.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00,  1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.8369702e-16,  1.0000000e+00,  0.0000000e+00],
         [-1.0000000e+00, -1.8369702e-16,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00,  1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 6.123234e-17,  1.000000e+00,  0.000000e+00],
         [ 1.000000e+00, -6.123234e-17,  0.000000e+00],
         [ 0.000000e+00,  0.000000e+00, -1.000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.0000000e+00,  1.2246468e-16,  0.0000000e+00],
         [ 1.2246468e-16,  1.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.8369702e-16, -1.0000000e+00,  0.0000000e+00],
         [-1.0000000e+00,  1.8369702e-16,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])}]

 # after this PR:
>>> get_symmetry_transformations(model_info_discrete, pi / 4)
[{'R': array([[1., 0., 0.],
         [0., 1., 0.],
         [0., 0., 1.]]),
  't': array([[0],
         [0],
         [0]])},
 {'R': array([[-1,  0,  0],
         [ 0, -1,  0],
         [ 0,  0,  1]]),
  't': array([[0],
         [0],
         [0]])}]

>>> get_symmetry_transformations(model_info_continuous, pi / 4)
[{'R': array([[1., 0., 0.],
         [0., 1., 0.],
         [0., 0., 1.]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.000000e+00,  0.000000e+00,  0.000000e+00],
         [ 0.000000e+00,  6.123234e-17, -1.000000e+00],
         [ 0.000000e+00,  1.000000e+00,  6.123234e-17]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.0000000e+00,  0.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00, -1.0000000e+00, -1.2246468e-16],
         [ 0.0000000e+00,  1.2246468e-16, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.0000000e+00,  0.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00, -1.8369702e-16,  1.0000000e+00],
         [ 0.0000000e+00, -1.0000000e+00, -1.8369702e-16]]),
  't': array([[0.],
         [0.],
         [0.]])}]

>>> get_symmetry_transformations(model_info_both, pi / 4)
[{'R': array([[1., 0., 0.],
         [0., 1., 0.],
         [0., 0., 1.]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 6.123234e-17, -1.000000e+00,  0.000000e+00],
         [ 1.000000e+00,  6.123234e-17,  0.000000e+00],
         [ 0.000000e+00,  0.000000e+00,  1.000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.0000000e+00, -1.2246468e-16,  0.0000000e+00],
         [ 1.2246468e-16, -1.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00,  1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.8369702e-16,  1.0000000e+00,  0.0000000e+00],
         [-1.0000000e+00, -1.8369702e-16,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00,  1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 1.,  0.,  0.],
         [ 0., -1.,  0.],
         [ 0.,  0., -1.]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[ 6.123234e-17,  1.000000e+00,  0.000000e+00],
         [ 1.000000e+00, -6.123234e-17,  0.000000e+00],
         [ 0.000000e+00,  0.000000e+00, -1.000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.0000000e+00,  1.2246468e-16,  0.0000000e+00],
         [ 1.2246468e-16,  1.0000000e+00,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])},
 {'R': array([[-1.8369702e-16, -1.0000000e+00,  0.0000000e+00],
         [-1.0000000e+00,  1.8369702e-16,  0.0000000e+00],
         [ 0.0000000e+00,  0.0000000e+00, -1.0000000e+00]]),
  't': array([[0.],
         [0.],
         [0.]])}]
```