### PR TITLE
WIP: Dataset tools

### DIFF
--- a/bop_toolkit_lib/dataset.py
+++ b/bop_toolkit_lib/dataset.py
@@ -1,0 +1,119 @@
+from pathlib import Path
+import numpy as np
+import json
+from bop_toolkit_lib.inout import (
+    load_im,
+    load_depth,
+    load_cam_params,
+    load_scene_camera,
+)
+
+
+def make_scene_infos(
+    scene_dir,
+    read_image_ids=True,
+    read_n_instances=True,
+):
+    # Outputs number of scenes, image ids for each scene.
+    scene_dir = Path(scene_dir)
+
+    infos = dict()
+    infos['has_rgb'] = (scene_dir / 'rgb').exists()
+    infos['has_depth'] = (scene_dir / 'depth').exists()
+    infos['has_gray'] = (scene_dir / 'gray').exists()
+    infos['has_mask'] = (scene_dir / 'masks').exists()
+    infos['has_mask_visib'] = (scene_dir / 'mask_visib').exists()
+
+    infos['has_gt'] = (scene_dir / 'scene_gt.json').exists()
+    infos['has_gt_info'] = (scene_dir / 'scene_gt_info.json').exists()
+    assert scene_dir / 'scene_camera.json'.exists()
+
+    return infos
+
+def get_scene_info(
+    scene_dir,
+):
+    return {
+        'has_depth': ,
+        'has_rgb': ,
+        'has_gray': ,
+            
+    }
+
+
+def load_image_data(
+    scene_dir,
+    image_id,
+    load_rgb,
+    load_gray,
+    load_depth,
+    load_mask_visib,
+    load_mask,
+    load_scene_gt=
+    scale_depth=True,
+    instance_id=None,
+):
+    """Loads all data for one image including images and annotations
+
+
+    :param scene_dir: _description_
+    :param image_id: _description_
+    :param instance_ids: _description_, defaults to None
+    :param load_masks_visib: _description_, defaults to True
+    :param load_masks: _description_, defaults to True
+    :param load_depth: _description_, defaults to True
+    :param load_rgb: _description_, defaults to True
+    :return: _description_
+    """
+
+    output = dict()
+
+    scene_dir = Path(scene_dir)
+    if isinstance(image_id, str):
+        image_id = int(image_id)
+        
+    scene_cameras = load_scene_camera(scene_dir / 'scene_camera.json')
+    camera = scene_cameras[str(image_id)]
+    output['camera'] = camera
+
+    if load_rgb:
+        rgb_path = scene_dir / 'rgb' / f'{image_id:06d}.jpg'
+        if not rgb_path.exists():
+            rgb_path = rgb_path.with_suffix('.png')
+        im_rgb = load_im(rgb_path).astype(np.uint8)
+        output['im_rgb'] = im_rgb
+
+    if load_gray:
+        gray_path = scene_dir / 'gray' / f'{image_id:06d}.tiff'
+        im_gray = load_im(gray_path).astype(np.uint8)
+        output['im_gray'] = im_gray
+    
+    if load_depth:
+        depth_path = scene_dir / 'depth' / f'{image_id:06d}.png'
+        im_depth = load_im(depth_path).astype(np.float32)
+        if scale_depth:
+            im_depth *= camera['depth_scale']
+        output['im_depth'] = im_depth
+    
+    if load_masks_visib:
+        if instance_ids is None:
+            
+    return x
+
+    
+def load_mesh_bop(
+    models_dir,
+):
+    return
+
+
+def load_mesh_shapenet(
+    models_dir,
+):
+    return
+
+
+def load_mesh_gso(
+    models_dir,
+):
+    return

--- a/bop_toolkit_lib/dataset/bop_v2.py
+++ b/bop_toolkit_lib/dataset/bop_v2.py
@@ -1,0 +1,161 @@
+import pathlib
+import numpy as np
+import json
+from bop_toolkit_lib import inout
+from bop_toolkit_lib import pycoco_utils
+
+
+def _save_scene_dict(
+    scene_dict,
+    image_tpath,
+    json_converter,
+):
+    for image_id, image_dict in scene_dict.items():
+        image_dict = json_converter(image_dict)
+        path = image_tpath.format(image_id=image_id)
+        inout.save_json(path, image_dict)
+    return
+
+
+def save_scene_camera(
+    scene_camera,
+    image_camera_tpath,
+):
+    _save_scene_dict(
+        scene_camera,
+        image_camera_tpath,
+        inout._camera_as_json
+    )
+    return
+
+
+def save_scene_gt(
+    scene_gt,
+    image_gt_tpath,
+):
+    _save_scene_dict(
+        scene_gt,
+        image_gt_tpath,
+        lambda lst: [inout._gt_as_json(d) for d in lst]
+    )
+    return
+
+
+def save_masks(
+    masks,
+    masks_path,
+):
+    masks_rle = dict()
+    for instance_id, mask in enumerate(masks):
+        mask_rle = pycoco_utils.binary_mask_to_rle(mask)
+        masks_rle[instance_id] = mask_rle
+    inout.save_json(masks_path, masks_rle)
+    return
+
+
+def io_load_masks(
+    mask_file,
+    instance_ids=None
+):
+    masks_rle = json.load(mask_file)
+    if instance_ids is not None:
+        instance_ids = masks_rle.keys()
+        instance_ids = sorted(instance_ids)
+    masks = np.stack([
+        pycoco_utils.rle_to_binary_mask(mask_rle)[:, :, None]
+        for mask_rle in masks_rle], axis=-1)
+    return masks
+
+
+def io_load_gt(
+    gt_file,
+    instance_ids=None,
+):
+    gt = json.load(gt_file)
+    if instance_ids is not None:
+        gt = [gt_n for n, gt_n in enumerate(gt) if n in instance_ids]
+    gt = [inout._gt_as_json(gt_n) for gt_n in gt]
+    return gt
+
+
+def load_image_infos(
+    dataset_dir,
+    image_key,
+):
+    def _file_path(ext):
+        return dataset_dir / f'{image_key}.{ext}'
+
+    infos = dict()
+    dataset_dir = pathlib.Path(dataset_dir)
+    has_rgb = _file_path('rgb.png').exists()
+    has_rgb = has_rgb or _file_path('rgb.jpg').exists()
+    infos['has_rgb'] = has_rgb
+    infos['has_depth'] = _file_path('depth.png').exsits()
+    infos['has_gray'] = _file_path('gray.tiff').exists()
+    infos['has_mask'] = _file_path('mask.png').exists()
+    infos['has_mask_visib'] = _file_path('mask_visib.png').exists()
+    infos['has_gt'] = _file_path('gt.json').exists()
+    infos['has_gt_info'] = _file_path('gt_info.json').exists()
+    return infos
+
+
+def load_image_data(
+    dataset_dir,
+    image_key,
+    load_rgb=True,
+    load_gray=False,
+    load_depth=True,
+    load_mask_visib=True,
+    load_mask=False,
+    load_gt=False,
+    load_gt_info=False,
+    rescale_depth=True,
+    instance_ids=None,
+):
+
+    def _file_path(ext):
+        return dataset_dir / f'{image_key}.{ext}'
+
+    image_data = dict()
+
+    camera = inout.load_json(_file_path('camera.json'))
+    camera = inout._camera_as_numpy(camera)
+    image_data['camera'] = camera
+
+    if load_rgb:
+        rgb_path = _file_path('rgb.jpg')
+        if not rgb_path.exists():
+            rgb_path = _file_path('rgb.png')
+        image_data['im_rgb'] = inout.load_im(rgb_path).astype(np.uint8)
+
+    if load_gray:
+        gray_path = _file_path('gray.tiff') 
+        im_gray = inout.load_im(gray_path).astype(np.uint8)
+        image_data['im_gray'] = im_gray
+    
+    if load_depth:
+        depth_path = _file_path('depth.png')
+        im_depth = inout.load_im(depth_path).astype(np.float32)
+        if rescale_depth:
+            im_depth *= camera['depth_scale']
+        image_data['im_depth'] = im_depth
+
+    if load_gt:
+        with open(_file_path('gt.json'), 'r') as f:
+            image_data['gt'] = io_load_gt(f, instance_ids=instance_ids)
+
+    if load_gt_info:
+        with open(_file_path('gt_info.json'), 'r') as f:
+            image_data['gt_info'] = io_load_gt(f, instance_ids=instance_ids)
+
+    if load_mask_visib:
+        with open(_file_path('mask_visib.json'), 'r') as f:
+            image_data['mask_visib'] = io_load_masks(
+                f, instance_ids=instance_ids)
+
+    if load_mask:
+        with open(_file_path('mask.json'), 'r') as f:
+            image_data['mask'] = io_load_masks(
+                f, instance_ids=instance_ids)
+
+    return image_data

--- a/bop_toolkit_lib/dataset/convert.py
+++ b/bop_toolkit_lib/dataset/convert.py
@@ -1,0 +1,6 @@
+def save_image_data_as_json(
+    image_data,
+    scene_id,
+    image_id,
+):
+    return

--- a/bop_toolkit_lib/dataset/convert.py
+++ b/bop_toolkit_lib/dataset/convert.py
@@ -1,6 +1,98 @@
-def save_image_data_as_json(
-    image_data,
-    scene_id,
-    image_id,
-):
-    return
+import argparse
+import shutil
+import pathlib
+from bop_toolkit_lib.dataset import bop_v1, bop_v2
+from tqdm import tqdm
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog='BOP-V1 -> BOP-V2 converter utility',
+    )
+    parser.add_argument('--input',
+                        help="""
+                        A directory containing the scenes of a dataset in v1
+                        format, e.g. ./ycbv/train_pbr.
+                        """, type=str, required=True)
+    parser.add_argument('--output',
+                        help="""
+                        Output directory that will contain the dataset
+                        in v2 format, e.g. ./ycbv/train_pbr_v2format
+                        """, type=str, required=True)
+    parser.add_argument('--scene-ids',
+                        help="""
+                        Scenes to be converted. If unspecified,
+                        all scenes will be converted.
+                        """, nargs='+', type=int)
+    args = parser.parse_args()
+    return args
+
+
+def main(args):
+    input_dir = pathlib.Path(args.input)
+    output_dir = pathlib.Path(args.output, exist_ok=True)
+
+    if args.scene_ids is not None:
+        scene_directories = (
+            input_dir / f'{scene_id:06d}' for scene_id in args.scene_ids)
+    else:
+        scene_directories = input_dir.iterdir()
+    
+    for scene_dir in tqdm(list(scene_directories)):
+        scene_id = int(scene_dir.name)
+
+        scene_data = bop_v1.load_scene_data(
+            scene_dir,
+            load_scene_camera=True,
+            load_scene_gt=True,
+            load_scene_gt_info=True
+        )
+
+        scene_infos = bop_v1.read_scene_infos(
+            scene_dir,
+        )
+
+        output_dir.mkdir(exist_ok=True)
+
+        image_tkey = f'{scene_id:06d}_' + '{image_id:06d}'
+
+        bop_v2.save_scene_camera(
+            scene_data['scene_camera'],
+            output_dir / (image_tkey + '.camera.json')
+        )
+
+        bop_v2.save_scene_gt(
+            scene_data['scene_gt'],
+            output_dir / (image_tkey + '.gt.json')
+        )
+
+        bop_v2.save_scene_gt(
+            scene_data['scene_gt_info'],
+            output_dir / (image_tkey + '.gt_info.json')
+        )
+
+        image_ids = [int(k) for k in scene_data['scene_camera'].keys()]
+        for image_id in image_ids:
+            image_key = image_tkey.format(image_id=image_id)
+            for mask_type in ('mask', 'mask_visib'):
+                if scene_infos['has_' + mask_type]:
+                    masks = bop_v1.load_masks(
+                        scene_dir, image_id, mask_type=mask_type)
+                    bop_v2.save_masks(
+                        masks,
+                        output_dir / (image_key + f'.{mask_type}.json')
+                    )
+        
+            for im_modality in ('rgb', 'gray', 'depth', ):
+                if scene_infos['has_' + im_modality]:
+                    im_path = list(
+                        (scene_dir / im_modality).glob(f'{image_id:06d}.*'))[0]
+                    suffix = im_path.suffix
+                    shutil.copy(
+                        im_path,
+                        output_dir / (image_key + '.' + im_modality + suffix)
+                    )
+
+
+if __name__ == '__main__':
+    main()

--- a/bop_toolkit_lib/dataset/plain_bop.py
+++ b/bop_toolkit_lib/dataset/plain_bop.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+import re
+import numpy as np
+import json
+import bop_toolkit_lib.inout as inout
+
+
+def read_scene_infos(
+    scene_dir,
+    read_image_ids=True,
+    read_n_objects=True,
+):
+    # Outputs number of scenes, image ids for each scene.
+    scene_dir = Path(scene_dir)
+
+    infos = dict()
+    infos['has_rgb'] = (scene_dir / 'rgb').exists()
+    infos['has_depth'] = (scene_dir / 'depth').exists()
+    infos['has_gray'] = (scene_dir / 'gray').exists()
+    infos['has_mask'] = (scene_dir / 'masks').exists()
+    infos['has_mask_visib'] = (scene_dir / 'mask_visib').exists()
+
+    infos['has_gt'] = (scene_dir / 'scene_gt.json').exists()
+    infos['has_gt_info'] = (scene_dir / 'scene_gt_info.json').exists()
+    assert (scene_dir / 'scene_camera.json').exists()
+
+    if read_image_ids:
+        scene_cameras = json.loads((scene_dir / 'scene_camera.json').read_text())
+        image_ids = [int(k) for k in scene_cameras.keys()]
+        infos['image_ids'] = image_ids
+
+    if infos['has_gt'] and read_n_objects:
+        scene_gt = json.loads((scene_dir / 'scene_gt.json').read_text())
+        infos['n_objects'] = len(scene_gt)
+
+    return infos
+
+
+def load_scene_data(
+    scene_dir,
+    load_scene_camera=True,
+    load_scene_gt=True,
+    load_scene_gt_info=True,
+
+):
+    scene_data = dict()
+    if load_scene_camera:
+        scene_camera = inout.load_scene_camera(scene_dir / 'scene_camera.json')
+        scene_data['scene_camera'] = scene_camera
+    if load_scene_gt:
+        scene_gt = inout.load_scene_gt(scene_dir / 'scene_gt.json')
+        scene_data['scene_gt'] = scene_gt
+    if load_scene_gt_info:
+        scene_gt_info = inout.load_scene_gt(scene_dir / 'scene_gt_info.json')
+        scene_data['scene_gt_info'] = scene_gt_info
+    return
+
+
+def load_image_data(
+    scene_dir,
+    image_id,
+    load_rgb=True,
+    load_gray=False,
+    load_depth=True,
+    load_mask_visib=True,
+    load_mask=False,
+    load_scene_gt=False,
+    load_scene_gt_info=False,
+    rescale_depth=True,
+):
+    """Loads all data for one image including images and annotations
+
+
+    :param scene_dir: _description_
+    :param image_id: _description_
+    :param instance_ids: _description_, defaults to None
+    :param load_masks_visib: _description_, defaults to True
+    :param load_masks: _description_, defaults to True
+    :param load_depth: _description_, defaults to True
+    :param load_rgb: _description_, defaults to True
+    :return: _description_
+    """
+
+    image_data = dict()
+
+    scene_dir = Path(scene_dir)
+    if isinstance(image_id, str):
+        image_id = int(image_id)
+
+    scene_cameras = inout.load_scene_camera(scene_dir / 'scene_camera.json')
+    camera = scene_cameras[image_id]
+    image_data['camera'] = camera
+
+    if load_rgb:
+        rgb_path = scene_dir / 'rgb' / f'{image_id:06d}.jpg'
+        if not rgb_path.exists():
+            rgb_path = rgb_path.with_suffix('.png')
+        im_rgb = inout.load_im(rgb_path).astype(np.uint8)
+        image_data['im_rgb'] = im_rgb
+
+    if load_gray:
+        gray_path = scene_dir / 'gray' / f'{image_id:06d}.tiff'
+        im_gray = inout.load_im(gray_path).astype(np.uint8)
+        image_data['im_gray'] = im_gray
+    
+    if load_depth:
+        depth_path = scene_dir / 'depth' / f'{image_id:06d}.png'
+        im_depth = inout.load_im(depth_path).astype(np.float32)
+        if rescale_depth:
+            im_depth *= camera['depth_scale']
+        image_data['im_depth'] = im_depth
+    
+    if load_scene_gt:
+        scene_gt = inout.load_scene_gt(scene_dir / 'scene_gt.json')
+        scene_gt = scene_gt[image_id]
+        image_data['scene_gt'] = scene_gt
+
+    if load_scene_gt_info:
+        scene_gt_info = inout.load_json(
+            scene_dir / 'scene_gt_info.json', keys_to_int=True)
+        scene_gt_info = scene_gt_info[str(image_id)]
+        image_data['scene_gt_info'] = scene_gt_info
+
+    if load_mask_visib:
+        mask_visib_paths = (
+            scene_dir / 'mask_visib').glob(f'{image_id:06d}_*.png')
+        mask_visib_paths = sorted(
+            mask_visib_paths,
+            key=lambda p: int(re.findall("\d+", p.name)[-1])
+        )
+        mask_visib = np.stack([
+            inout.load_im(p) for p in mask_visib_paths
+        ], axis=-1)
+        image_data['mask_visib'] = mask_visib
+
+    if load_mask:
+        mask_paths = (
+            scene_dir / 'mask').glob(f'{image_id:06d}_*.png')
+        mask_paths = sorted(
+            mask_paths,
+            key=lambda p: int(re.findall("\d+", p.name)[-1])
+        )
+        mask = np.stack([
+            inout.load_im(p) for p in mask_paths
+        ], axis=-1)
+        image_data['mask'] = mask
+
+    return image_data

--- a/bop_toolkit_lib/inout.py
+++ b/bop_toolkit_lib/inout.py
@@ -137,6 +137,29 @@ def load_cam_params(path):
   return cam
 
 
+def _camera_as_numpy(camera):
+  if 'cam_K' in camera.keys():
+    camera['cam_K'] = \
+      np.array(camera['cam_K'], np.float64).reshape((3, 3))
+  if 'cam_R_w2c' in camera.keys():
+    camera['cam_R_w2c'] = \
+      np.array(camera['cam_R_w2c'], np.float64).reshape((3, 3))
+  if 'cam_t_w2c' in camera.keys():
+    camera['cam_t_w2c'] = \
+      np.array(camera['cam_t_w2c'], np.float64).reshape((3, 1))
+  return camera
+
+
+def _camera_as_json(camera):
+  if 'cam_K' in camera.keys():
+    camera['cam_K'] = camera['cam_K'].flatten().tolist()
+  if 'cam_R_w2c' in camera.keys():
+    camera['cam_R_w2c'] = camera['cam_R_w2c'].flatten().tolist()
+  if 'cam_t_w2c' in camera.keys():
+    camera['cam_t_w2c'] = camera['cam_t_w2c'].flatten().tolist()
+  return camera
+
+
 def load_scene_camera(path):
   """Loads content of a JSON file with information about the scene camera.
 
@@ -148,15 +171,7 @@ def load_scene_camera(path):
   scene_camera = load_json(path, keys_to_int=True)
 
   for im_id in scene_camera.keys():
-    if 'cam_K' in scene_camera[im_id].keys():
-      scene_camera[im_id]['cam_K'] = \
-        np.array(scene_camera[im_id]['cam_K'], np.float64).reshape((3, 3))
-    if 'cam_R_w2c' in scene_camera[im_id].keys():
-      scene_camera[im_id]['cam_R_w2c'] = \
-        np.array(scene_camera[im_id]['cam_R_w2c'], np.float64).reshape((3, 3))
-    if 'cam_t_w2c' in scene_camera[im_id].keys():
-      scene_camera[im_id]['cam_t_w2c'] = \
-        np.array(scene_camera[im_id]['cam_t_w2c'], np.float64).reshape((3, 1))
+    scene_camera[im_id] = _camera_as_numpy(scene_camera[im_id])
   return scene_camera
 
 
@@ -169,14 +184,27 @@ def save_scene_camera(path, scene_camera):
   :param scene_camera: Dictionary to save to the JSON file.
   """
   for im_id in sorted(scene_camera.keys()):
-    im_camera = scene_camera[im_id]
-    if 'cam_K' in im_camera.keys():
-      im_camera['cam_K'] = im_camera['cam_K'].flatten().tolist()
-    if 'cam_R_w2c' in im_camera.keys():
-      im_camera['cam_R_w2c'] = im_camera['cam_R_w2c'].flatten().tolist()
-    if 'cam_t_w2c' in im_camera.keys():
-      im_camera['cam_t_w2c'] = im_camera['cam_t_w2c'].flatten().tolist()
+    scene_camera[im_id] = _camera_as_json(scene_camera[im_id])
   save_json(path, scene_camera)
+
+
+def _gt_as_numpy(gt):
+  if 'cam_R_m2c' in gt.keys():
+    gt['cam_R_m2c'] = \
+      np.array(gt['cam_R_m2c'], np.float64).reshape((3, 3))
+  if 'cam_t_m2c' in gt.keys():
+    gt['cam_t_m2c'] = \
+      np.array(gt['cam_t_m2c'], np.float64).reshape((3, 1))
+  return gt
+
+def _gt_as_json(gt):
+  if 'cam_R_m2c' in gt.keys():
+    gt['cam_R_m2c'] = gt['cam_R_m2c'].flatten().tolist()
+  if 'cam_t_m2c' in gt.keys():
+    gt['cam_t_m2c'] = gt['cam_t_m2c'].flatten().tolist()
+  if 'obj_bb' in gt.keys():
+    gt['obj_bb'] = [int(x) for x in gt['obj_bb']]
+  return gt
 
 
 def load_scene_gt(path):


### PR DESCRIPTION
- Write a script to convert BOP-v1 to a new format called BOP-v2 (see below).
- Add convenient functions to read images from the datasets stored in the BOP-v1 or BOP-v2 formats.

The two main features of BOP-v2 are:
- All object masks for an image are stored in a single .json format and use RLE encoding.
- The object and camera annotations are stored in individual files (one file per image instead of one per ). This allows faster reading of individual images and annotations.

- [ ] Add multi-processing option to the conversion script.
- [ ] Convert existing PBR datasets to BOP-v2.
- [ ] Add utilities for packing BOP-v2 into webdatasets chunks and add documentation for how to read it.