### PR TITLE
Adding multiprocessing (10 workers) for the scoring part in eval_bop19_pose.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ ENV/
 .idea
 scripts_internal/
 bop_toolkit_lib/config_internal.py
+.vscode/ 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ python scripts/eval_bop19.py --renderer_type=vispy --result_filenames=NAME_OF_CS
 
 `--result_filenames`: Comma-separated filenames with pose estimates in .csv ([examples](https://bop.felk.cvut.cz/media/data/bop_sample_results/bop_challenge_2019_sample_results.zip)).
 
+By default, this script is run with 10 parallel processes. You can change the number of processes by setting the `--num_worker 1`.
+
 ### 5. Evaluate the detections / instance segmentations
 ```
 python scripts/eval_bop22_coco.py --result_filenames=NAME_OF_JSON_WITH_COCO_RESULTS --ann_type='bbox'

--- a/bop_toolkit_lib/misc.py
+++ b/bop_toolkit_lib/misc.py
@@ -418,3 +418,13 @@ def run_meshlab_script(
     log(" ".join(meshlabserver_cmd))
     if subprocess.call(meshlabserver_cmd) != 0:
         exit(-1)
+
+
+def run_command(cmd):
+    """Runs a command.
+
+    :param cmd: Command to run.
+    """
+    log("Running: " + " ".join(cmd))
+    if subprocess.call(cmd) != 0:
+        raise RuntimeError(f"{cmd} failed!")


### PR DESCRIPTION
There are two parts in eval_bop19_pose.py: calculating errors and scoring. I batch the scoring part with 10 workers, and add this option in README. 

This batching makes the run-time around 2x faster (of course without changing the score) on LM-O and TUD-L evaluation:
LM-O: 38.5 seconds instead of 73.5 seconds
TUD-L: 26.1 seconds instead of 59.2 seconds

I will batch the calculating errors part too (which is the only remaining bottleneck).

@thodan @ylabbe Please review and approve it!