### PR TITLE
Fixed bug from concatenating list and iterator

### DIFF
--- a/bop_toolkit_lib/inout.py
+++ b/bop_toolkit_lib/inout.py
@@ -776,7 +776,7 @@ def save_ply2(
             if texture_uv_face is not None:
                 uv = texture_uv_face[face_id]
                 line += " " + " ".join(
-                    map(str, [len(uv)] + map(float, list(uv.squeeze())))
+                    map(str, [len(uv)] + list(map(float, list(uv.squeeze()))))
                 )
             f.write(line)
             f.write("\n")


### PR DESCRIPTION
Hi all,

This is a simple one-line fix in `inout.save_ply2`. Within the outer `map` function, it tries to concatenate the list `[len(uv)]` and the iterator `map(float, list(...))`, which causes `TypeError: can only concatenate list (not "map") to list`.

https://github.com/thodan/bop_toolkit/blob/91d9d7051180ba4976eda321ee51a7ea98d65c3c/bop_toolkit_lib/inout.py#L779

To fix it, I simply wrapped the `map` iterator with a call to `list`. Can you merge this when you get a chance, so I don't have to reimplement this function myself? Thanks!

--Stephen