### PR TITLE
Hand Tracking Toolkit as an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ python scripts/eval_bop24_pose.py --result_filenames=NAME_OF_CSV_WITH_RESULTS --
 
 `--result_filenames`: Comma-separated filenames with pose estimates in .csv ([examples](https://bop.felk.cvut.cz/media/data/bop_sample_results/bop_challenge_2019_sample_results.zip)).
 
+#### HOT3D special case
+The [Hand Tracking Toolkit](https://github.com/facebookresearch/hand_tracking_toolkit) Fisheye camera implementation is necessary for evaluation on the HOT3D dataset. Install with:  
+
+`pip install git+https://github.com/facebookresearch/hand_tracking_toolkit`
+
 ### 5. Evaluate the pose estimates for 6D localization task
 ```
 python scripts/eval_bop19_pose.py --renderer_type=vispy --result_filenames=NAME_OF_CSV_WITH_RESULTS

--- a/bop_toolkit_lib/misc.py
+++ b/bop_toolkit_lib/misc.py
@@ -15,8 +15,6 @@ from scipy.spatial import distance
 
 from bop_toolkit_lib import transform
 
-from hand_tracking_toolkit.camera import model_by_name, CameraModel 
-
 logging.basicConfig()
 
 
@@ -112,62 +110,6 @@ def project_pts(pts, K, R, t):
     pts_im /= pts_im[2, :]
     return pts_im[:2, :].T
 
-
-def project_pts_htt(pts, cam: CameraModel, R, t):
-    """Transform and projects points with Hand Tracking Toolbox CameraModel.
-
-    :param pts: nx3 ndarray with the 3D points.
-    :param cam: HTT CameraModel instance.
-    :param R: 3x3 ndarray with a rotation matrix.
-    :param t: 3x1 ndarray with a translation vector.
-    :return: nx2 ndarray with 2D image coordinates of the projections.
-    """
-
-    pts_w = transform_pts_Rt(pts, R, t)
-    pts_im = cam.eye_to_window(pts_w)
-
-    return pts_im 
-
-
-def create_camera_model(camera: dict):
-    """Create a Hand Tracking Toolkit Camera model from a scene camera.
-    
-
-    """
-    if "cam_K" in camera:        
-        K = camera["cam_K"]            
-        fx, fy = K[0,0], K[1,1]
-        cx, cy = K[0,2], K[1,2]
-        width, height = 1,1
-        model = "PinholePlane"
-        coeffs = ()
-    
-    elif "cam_model" in camera:
-        calib = camera["cam_model"]
-        width = calib["image_width"]
-        height = calib["image_height"]
-        model = calib["projection_model_type"]
-
-        if model == "CameraModelType.FISHEYE624" and len(calib["projection_params"]) == 15:
-            # TODO: Aria data hack
-            f, cx, cy = calib["projection_params"][:3]
-            fx = fy = f
-            coeffs = calib["projection_params"][3:]
-        else:
-            fx, fy, cx, cy = calib["projection_params"][:4]
-            coeffs = calib["projection_params"][4:]
-
-    else:
-        raise ValueError("Scene camera data missing 'cam_K' or 'cam_model' fields")
-
-    cls = model_by_name[model]
-    return cls(
-        width,
-        height,
-        (fx, fy),
-        (cx, cy),
-        coeffs
-    )
 
 
 class Precomputer(object):

--- a/bop_toolkit_lib/tests/test_misc.py
+++ b/bop_toolkit_lib/tests/test_misc.py
@@ -3,6 +3,7 @@ import numpy as np
 import unittest
 from bop_toolkit_lib import misc
 from bop_toolkit_lib import misc_torch as misct
+from bop_toolkit_lib import pose_error_htt
 from bop_toolkit_lib import transform
 
 from hand_tracking_toolkit.camera import PinholePlaneCameraModel
@@ -87,7 +88,7 @@ class TestMisc(unittest.TestCase):
         camera = PinholePlaneCameraModel(width=fx, height=fy, f=(fx,fy), c=(cx,cy), distort_coeffs=())
         proj_htt = np.zeros((self.B,self.Np,2))
         for i in range(self.B):
-            proj_htt[i] = misc.project_pts_htt(self.pts, camera, R_np[i], t_np[i])
+            proj_htt[i] = pose_error_htt.project_pts_htt(self.pts, camera, R_np[i], t_np[i])
         self.assertTrue(np.allclose(proj_htt, proj_np, atol=1e-4))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ glumpy==1.1.0
 opencv-python>=4.3.0.36
 Pillow>=8.2.0
 git+https://github.com/MartinSmeyer/cocoapi.git@v1.0#subdirectory=PythonAPI
-git+https://github.com/facebookresearch/hand_tracking_toolkit
 vispy>=0.6.5
 webdataset>=0.1.62
 numpy

--- a/scripts/eval_calc_errors.py
+++ b/scripts/eval_calc_errors.py
@@ -29,7 +29,8 @@ try:
     htt_available = True
 except ImportError as e:
     logger.warn("""Missing hand_tracking_toolkit dependency, 
-                this script will not be compatible with H3 BOP24 datasets
+                mandatory if you are running evaluation on HOT3d. 
+                Refer to the README.md for installation instructions.
                 """)
 
 # PARAMETERS (can be overwritten by the command line arguments below).

--- a/scripts/eval_calc_errors_gpu.py
+++ b/scripts/eval_calc_errors_gpu.py
@@ -8,7 +8,6 @@ import time
 import argparse
 import copy
 import numpy as np
-import torch
 
 
 from bop_toolkit_lib import config
@@ -20,6 +19,12 @@ from bop_toolkit_lib import pose_error_gpu
 # Get the base name of the file without the .py extension
 file_name = os.path.splitext(os.path.basename(__file__))[0]
 logger = misc.get_logger(file_name)
+
+try:
+    import torch
+except ImportError as e:
+    logger.error('torch is required for gpu based evaluation (see bop_toolkit/README.md)')
+    raise e
 
 # PARAMETERS (can be overwritten by the command line arguments below).
 ################################################################################


### PR DESCRIPTION
Make Hand Tracking Toolkit an optional dependency. 
Use previous API to compute MSPD on pinhole model images and the HTT CameraModel for Fisheye (HOT3D). Logs clear error messages if uncompatible setup/dataset.

Fixes https://github.com/thodan/bop_toolkit/issues/134