### PR TITLE
Fix errors of not getting 100 score when evaluating with GT

### DIFF
--- a/bop_toolkit_lib/pose_matching.py
+++ b/bop_toolkit_lib/pose_matching.py
@@ -91,7 +91,7 @@ def match_poses(errs, error_ths, max_ests_count=0, gt_valid_mask=None):
 
 
 def match_poses_scene(
-    scene_id, scene_gt, scene_gt_valid, scene_errs, correct_th, n_top
+    scene_id, scene_gt, scene_gt_info, scene_gt_valid, scene_errs, correct_th, n_top
 ):
     """Matches the estimated poses to the ground-truth poses in one scene.
 
@@ -124,6 +124,7 @@ def match_poses_scene(
         im_matches = []
 
         for gt_id, gt in enumerate(im_gts):
+            
             im_matches.append(
                 {
                     "scene_id": scene_id,
@@ -135,7 +136,7 @@ def match_poses_scene(
                     "error": -1,
                     "error_norm": -1,
                     "valid": scene_gt_valid[im_id][gt_id],
-                    "gt_visib_fract": -1, # initialize for each gt valid as -1
+                    "gt_visib_fract": scene_gt_info[im_id][gt_id]["visib_fract"], 
                 }
             )
 
@@ -157,7 +158,7 @@ def match_poses_scene(
                     g["score"] = m["score"]
                     g["error"] = m["error"]
                     g["error_norm"] = m["error_norm"]
-                    g["gt_visib_fract"] = m["gt_visib_fract"] # update gt_visib_fract
+                    g["gt_visib_fract"] = m["gt_visib_fract"]
 
         scene_matches += im_matches
 

--- a/bop_toolkit_lib/score.py
+++ b/bop_toolkit_lib/score.py
@@ -181,7 +181,7 @@ def calc_pose_detection_scores(
     visib_gt_min,
     ignore_object_visible_less_than_visib_gt_min,
     do_print=True,
-    double_check_size=True,
+    double_check_size=False,
 ):
     """Calculates performance scores for the 6D object detection task.
 

--- a/bop_toolkit_lib/score.py
+++ b/bop_toolkit_lib/score.py
@@ -274,7 +274,7 @@ def calc_pose_detection_scores(
                     else:
                         false_negatives[i] = True
                 # If there is no match, then it is a false negative, except when GT is not visible enough
-                elif m["gt_visib_fract"] < visib_gt_min:
+                elif m["gt_visib_fract"]!= -1 and m["gt_visib_fract"] < visib_gt_min:
                     false_negatives_ignore[i] = True
                 else:
                     false_negatives[i] = True

--- a/bop_toolkit_lib/score.py
+++ b/bop_toolkit_lib/score.py
@@ -289,7 +289,7 @@ def calc_pose_detection_scores(
 
             # Double check the size of GT is correct
             num_gts = len([m for m in obj_matches if m["valid"] and m["gt_visib_fract"] >= visib_gt_min])
-            assert np.sum(true_positives) + np.sum(false_negatives) + np.sum(false_negatives_ignore) == num_gts, f"TP={np.sum(true_positives)}, FN={np.sum(false_negatives)}, FN_ignore={np.sum(false_negatives_ignore)}, num_gts={num_gts}"
+            assert np.sum(true_positives) + np.sum(false_negatives) == num_gts, f"TP={np.sum(true_positives)}, FN={np.sum(false_negatives)}, num_gts={num_gts}"
 
         # remove the false positives that are ignored
         keep_idx = np.logical_and(np.invert(false_positives_ignore), np.invert(false_negatives_ignore))

--- a/bop_toolkit_lib/score.py
+++ b/bop_toolkit_lib/score.py
@@ -231,8 +231,7 @@ def calc_pose_detection_scores(
     # Then calculate the average precision for each object.
     scores_per_object = {}
     num_instances_per_object = {}
-    total_num_false_positives_ignore = 0
-    total_num_false_negatives_ignore = 0
+    total_num_false_ignore = 0
     for obj_id, obj_tar in obj_tars.items():
         obj_matches = [m for m in matches if m["obj_id"] == obj_id]
 
@@ -250,52 +249,44 @@ def calc_pose_detection_scores(
         false_negatives = np.zeros(len(sorted_obj_matches), dtype=np.bool_)
 
         # False Positive Ignore: A detection that has no matching GT having visib_gt_fract < visib_gt_min.
-        false_positives_ignore = np.zeros(len(sorted_obj_matches), dtype=np.bool_)
-
-        # False Negative Ignore: A GT having visib_gt_fract < visib_gt_min, has no matching detection.
-        false_negatives_ignore = np.zeros(len(sorted_obj_matches), dtype=np.bool_)
+        false_ignore = np.zeros(len(sorted_obj_matches), dtype=np.bool_)
 
         for i, m in enumerate(sorted_obj_matches):
-            # valid is object_id in target list, and visib_gt_fract >= visib_gt_min
-            # est_id is when there is a match
+            # valid is object_id in target list
+            # est_id != -1 is when there is a match, -1 otherwise
 
-            # If the GT is in target list
-            if m["valid"]: 
-                # and there is a match
-                if m["est_id"] != -1: 
-                    # and the GT is visible enough, then it is a true positive
+            # Case 1: Detection is a match.
+            if m["est_id"] != -1: 
+                if m["valid"]:
                     if m["gt_visib_fract"] >= visib_gt_min:
                         true_positives[i] = True
-                    # if not, then it is a false negative except when: 
-                    # 1. ignore_object_visible_less_than_visib_gt_min is True 
-                    # 2. the GT is not visible enough
-                    elif m["gt_visib_fract"] < visib_gt_min and ignore_object_visible_less_than_visib_gt_min: # ignore object visible less than visib_gt_min
-                        false_positives_ignore[i] = True
+                    elif m["gt_visib_fract"] < visib_gt_min and ignore_object_visible_less_than_visib_gt_min:
+                        false_ignore[i] = True
                     else:
-                        false_negatives[i] = True
-                # If there is no match, then it is a false negative, except when GT is not visible enough
-                elif m["gt_visib_fract"]!= -1 and m["gt_visib_fract"] < visib_gt_min:
-                    false_negatives_ignore[i] = True
+                        print("Warning: not using ignore_object_visible_less_than_visib_gt_min")
                 else:
+                    # est_id != -1 and valid is always together.
+                    print(f"Warning: not using valid {m}")
+            # Case 2: Detection is not a match and it is a valid GT.
+            elif m["valid"]:
+                if m["gt_visib_fract"] >= visib_gt_min:
                     false_negatives[i] = True
+                elif m["gt_visib_fract"] < visib_gt_min:
+                    false_ignore[i] = True
+            # Case 3: Detection is not a match and it is not a valid GT.
             else:
-                # If the GT is not in target list, then it is a false positive
                 false_positives[i] = True
-        
+    
         if double_check_size:
-            # Double check the size of prediction is correct
-            num_dets = len([m for m in obj_matches if m["est_id"] != -1])
-            assert np.sum(true_positives) + np.sum(false_positives) + np.sum(false_positives_ignore) == num_dets, f"TP={np.sum(true_positives)}, FP={np.sum(false_positives)}, FP_ignore={np.sum(false_positives_ignore)}, num_dets={num_dets}"
-
             # Double check the size of GT is correct
-            num_gts = len([m for m in obj_matches if m["valid"] and m["gt_visib_fract"] >= visib_gt_min])
-            assert np.sum(true_positives) + np.sum(false_negatives) == num_gts, f"TP={np.sum(true_positives)}, FN={np.sum(false_negatives)}, num_gts={num_gts}"
+            num_gts = len([m for m in obj_matches if m["valid"]])
+            assert np.sum(true_positives) + np.sum(false_negatives) + np.sum(false_ignore) == num_gts, f"TP={np.sum(true_positives)}, FN={np.sum(false_negatives)}, num_gts={num_gts}"
 
         # remove the false positives that are ignored
-        keep_idx = np.logical_and(np.invert(false_positives_ignore), np.invert(false_negatives_ignore))
+        keep_idx = np.invert(false_ignore)
         true_positives = true_positives[keep_idx]
         false_positives = false_positives[keep_idx]
-        obj_tar = obj_tar - np.sum(false_positives_ignore) - np.sum(false_negatives_ignore)
+        obj_tar = obj_tar - np.sum(false_ignore)
 
         cum_true_positives = np.cumsum(true_positives)
         cum_false_positives = np.cumsum(false_positives)
@@ -303,21 +294,18 @@ def calc_pose_detection_scores(
         # Recall, Precision.
         recall = cum_true_positives / int(obj_tar)
         precision = cum_true_positives / (cum_true_positives + cum_false_positives)
+        precision[np.isnan(precision)] = 0
+
         ap = calc_ap(recall, precision, coco_interpolation=True)
         scores_per_object[obj_id] = ap
         num_instances_per_object[obj_id] = int(obj_tar)
         if do_print:
             misc.log("Object {:d} AP: {:.4f}".format(obj_id, ap))
-            if np.sum(false_positives_ignore) > 0:
+            if np.sum(false_ignore) > 0:
                 misc.log(
-                    f"Number of false positives ignored: {np.sum(false_positives_ignore)}"
+                    f"Number of false ignored: {np.sum(false_ignore)}"
                 )
-            if np.sum(false_negatives_ignore) > 0:
-                misc.log(
-                    f"Number of false negatives ignored: {np.sum(false_negatives_ignore)}"
-                )
-        total_num_false_positives_ignore += np.sum(false_positives_ignore)
-        total_num_false_negatives_ignore += np.sum(false_negatives_ignore)
+        total_num_false_ignore += np.sum(false_ignore)
 
     # Final scores.
     scores = {
@@ -332,8 +320,7 @@ def calc_pose_detection_scores(
         misc.log("Estimates count:    {:d}".format(scores["num_estimates"]))
         misc.log("GT count:           {:d}".format(scores["gt_count"]))
         misc.log("Target count:       {:d}".format(scores["targets_count"]))
-        misc.log("Total number of false positives ignored: {:d}".format(total_num_false_positives_ignore))
-        misc.log("Total number of false negatives ignored: {:d}".format(total_num_false_negatives_ignore))
+        misc.log("Total number of false ignored: {:d}".format(total_num_false_ignore))
         misc.log("")
 
     return scores

--- a/bop_toolkit_lib/tests/README.md
+++ b/bop_toolkit_lib/tests/README.md
@@ -35,7 +35,9 @@ python bop_toolkit_lib/tests/eval_bop24_pose_test_gpu.py --num_false_positives 1
 
 ## Test of 6D detetection with only objects visible > 10% in the image
 ```
-python scripts/eval_bop24_pose.py --renderer_type=vispy --results_path ./bop_toolkit_lib/tests/data/ --eval_path ./bop_toolkit_lib/tests/data/ --result_filenames unittest-minVisib0_tless-test_16ab01bd-f020-4194-9750-d42fc7f875d2.csv --num_worker 10
+python scripts/eval_bop24_pose.py --renderer_type=vispy --results_path ./bop_toolkit_lib/tests/data/ --eval_path ./bop_toolkit_lib/tests/data/ --result_filenames unittest-minVisib0_lmo-test_16ab01bd-f020-4194-9750-d42fc7f875d2.csv --num_worker 10 --targets_filename test_targets_bop19.json
+
+python scripts/eval_bop24_pose.py --renderer_type=vispy --results_path ./bop_toolkit_lib/tests/data/ --eval_path ./bop_toolkit_lib/tests/data/ --result_filenames unittest-minVisib0_tless-test_16ab01bd-f020-4194-9750-d42fc7f875d2.csv --num_worker 10 --targets_filename test_targets_bop19.json
 ```
 
 Results:

--- a/scripts/eval_bop24_pose.py
+++ b/scripts/eval_bop24_pose.py
@@ -238,6 +238,7 @@ for result_filename in p["result_filenames"]:
                     if num_instances_per_object[obj_id] > 0:
                         mAP_scores_per_object.setdefault(obj_id, []).append(scores[obj_id])
                     else:
+                        mAP_scores_per_object.setdefault(obj_id, []).append(0)
                         num_object_ids_ignored.append(obj_id)
                         logger.warning(
                             f"Object {obj_id} not found in the dataset. Skipping object {obj_id} in mAP calculation."
@@ -252,7 +253,7 @@ for result_filename in p["result_filenames"]:
             mAP_over_correct_ths = []
             for obj_id in mAP_scores_per_object:
                 # make sure that the object is not ignored
-                assert obj_id not in num_object_ids_ignored
+                # assert obj_id not in num_object_ids_ignored
 
                 mAP_over_correct_th = np.mean(mAP_scores_per_object[obj_id])
                 logger.info(

--- a/scripts/eval_calc_scores.py
+++ b/scripts/eval_calc_scores.py
@@ -238,6 +238,7 @@ for error_dir_path in p["error_dir_paths"]:
 
         # Keep GT poses only for the selected targets.
         scene_gt_curr = {}
+        scene_gt_curr_info = {}
         scene_gt_valid = {}
         for im_id, im_targets in scene_targets.items():
 
@@ -248,7 +249,7 @@ for error_dir_path in p["error_dir_paths"]:
                 im_targets = inout.get_im_targets(im_gt=im_gt, im_gt_info=im_gt_info, visib_gt_min=p["visib_gt_min"], eval_mode=p["eval_mode"])
 
             scene_gt_curr[im_id] = scene_gt[im_id]
-
+            scene_gt_curr_info[im_id] = scene_gt_info[im_id]
             # Determine which GT poses are valid.
             im_gt = scene_gt[im_id]
             im_gt_info = scene_gt_info[im_id]
@@ -309,6 +310,7 @@ for error_dir_path in p["error_dir_paths"]:
         matches += pose_matching.match_poses_scene(
             scene_id,
             scene_gt_curr,
+            scene_gt_curr_info,
             scene_gt_valid,
             scene_errs,
             p["correct_th"][err_type],


### PR DESCRIPTION
This PR fixes the problem of not getting 100% when evaluating with GT pose on 6D detection task:

- Problem: This error is when we have GT< 10% but we still keep it in order to use the flag `ignoring_less_than_min_visib` in [eval_bop24_pose.py](https://github.com/nv-nguyen/bop_toolkit/blob/master/scripts/eval_bop24_pose.py) so that the detection for these GTs are not counted as false positives. However, these additional GT creates more false negative for other submissions that do not have estimates that matches with these GT having visibility < 10%.

- Solution: In order to use `ignoring_less_than_min_visib`, we still keep all GT/detections and classify them into 5 types:
  - true positive: a correct detection that matches with GT having `visib_gt_fract >= visib_gt_min`
  - false positive: a detection that has no matching GT having `visib_gt_fract >= visib_gt_min`
  - **false positive ignore:** a detection that matches with GT having `visib_gt_fract < visib_gt_min`
  - false negative: a GT has `visib_gt_fract >= visib_gt_min` and has no matching detection
  - **false negative ignore:** a GT has `visib_gt_fract < visib_gt_min` and has no matching detection.

Test plan:

```
python scripts/eval_bop24_pose.py --renderer_type=vispy --results_path ./bop_toolkit_lib/tests/data/ --eval_path ./bop_toolkit_lib/tests/data/ --result_filenames unittest-minVisib0_lmo-test_16ab01bd-f020-4194-9750-d42fc7f875d2.csv --num_worker 10 --targets_filename test_targets_bop19.json

python scripts/eval_bop24_pose.py --renderer_type=vispy --results_path ./bop_toolkit_lib/tests/data/ --eval_path ./bop_toolkit_lib/tests/data/ --result_filenames unittest-minVisib0_tless-test_16ab01bd-f020-4194-9750-d42fc7f875d2.csv --num_worker 10 --targets_filename test_targets_bop19.json
```