### PR TITLE
hb detection6d eval

### DIFF
--- a/bop_toolkit_lib/score.py
+++ b/bop_toolkit_lib/score.py
@@ -280,7 +280,10 @@ def calc_pose_detection_scores(
         # Cumulative sums (this can be done as we sorted the matches at the beginning).
         true_positive_cumsum = np.cumsum(true_positive_mask)
         false_positive_cumsum = valid_obj_dets_count - true_positive_cumsum
-        assert np.min(false_positive_cumsum) >= 0
+        # this assert is only valid in the case that this obj is associated with
+        # at least one gt target (np.min fails on length 0 arrays)
+        if len(false_positive_cumsum) > 0:
+            assert np.min(false_positive_cumsum) >= 0
 
         # The number of target object instances (i.e. valid GT annotations).
         num_obj_targets = np.sum(true_positive_mask) + np.sum(false_negative_mask)

--- a/scripts/eval_bop24_pose.py
+++ b/scripts/eval_bop24_pose.py
@@ -233,7 +233,6 @@ for result_filename in p["result_filenames"]:
                 num_instances_per_object = inout.load_json(scores_path)[
                     "num_targets_per_object"
                 ]
-
                 for obj_id in scores:
                     if num_instances_per_object[obj_id] > 0:
                         mAP_scores_per_object.setdefault(obj_id, []).append(scores[obj_id])
@@ -252,8 +251,10 @@ for result_filename in p["result_filenames"]:
                 )
             mAP_over_correct_ths = []
             for obj_id in mAP_scores_per_object:
-                # make sure that the object is not ignored
-                # assert obj_id not in num_object_ids_ignored
+                # if the object has zero instance, it means it was not among the targets
+                # and should not be considered for final AP computation
+                if num_instances_per_object[obj_id] == 0:
+                    continue
 
                 mAP_over_correct_th = np.mean(mAP_scores_per_object[obj_id])
                 logger.info(


### PR DESCRIPTION
HomebrewedDB is a special case in that not all its object ids are included in the evaluation test targets, this PR fixes minor issues in the 6D detection code.

- fix crashing
- only use objects present in the target ground-truths for the final mAP computations