### PR TITLE
Support ROS 2 builds

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,8 @@
   <license>Apache license 2.0</license>
 
   <test_depend>ament_black</test_depend>
+  <exec_depend>python3-imageio</exec_depend>
+  <exec_depend>python3-pypng</exec_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -8,9 +8,18 @@
   <maintainer email="Martin.Sundermeyer@dlr.de">Martin Sundermeyer</maintainer>
   <license>Apache license 2.0</license>
 
-  <test_depend>ament_black</test_depend>
+  <exec_depend>cython3</exec_depend>
   <exec_depend>python3-imageio</exec_depend>
+  <exec_depend>python3-kiwisolver</exec_depend>
+  <exec_depend>python3-matplotlib</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>python3-opengl</exec_depend>
+  <exec_depend>python3-pil</exec_depend>
   <exec_depend>python3-pypng</exec_depend>
+  <exec_depend>python3-scipy</exec_depend>
+
+  <test_depend>ament_black</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>bop_toolkit_lib</name>
+  <version>1.0.0</version>
+  <description>A Python toolkit of the BOP benchmark for 6D object pose estimation.</description>
+  <maintainer email="tom.hodan@gmail.com">Tomas Hodan</maintainer>
+  <maintainer email="Martin.Sundermeyer@dlr.de">Martin Sundermeyer</maintainer>
+  <license>Apache license 2.0</license>
+
+  <test_depend>ament_black</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/bop_toolkit_lib
+[install]
+install_scripts=$base/lib/bop_toolkit_lib

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import setup, find_packages
 
+package_name = 'bop_toolkit_lib'
+
 setup(
-    name="bop_toolkit_lib",
+    name=package_name,
     version="1.0",
     packages=find_packages(exclude=("docs")),
     install_requires=["pytz", "vispy>=0.6.5", "PyOpenGL==3.1.0", "pypng", "cython"],
@@ -9,4 +11,9 @@ setup(
     author_email="tom.hodan@gmail.com, Martin.Sundermeyer@dlr.de",
     license="MIT license",
     package_data={"bop_toolkit_lib": ["*"]},
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
 )


### PR DESCRIPTION
This PR adds a `package.xml` file which is a [standard descriptor for ROS packages](https://www.ros.org/reps/rep-0140.html) along with some minor changes to allow downstream ROS packages to depend on this library. 