### PR TITLE
Fix bug eval bop 24 with multiple results_path

### DIFF
--- a/scripts/eval_bop24_pose.py
+++ b/scripts/eval_bop24_pose.py
@@ -256,10 +256,12 @@ for result_filename in result_filenames:
                     f"mAP, {error['type']}, {obj_id}: {mAP_over_correct_th:.3f}"
                 )
                 mAP_over_correct_ths.append(mAP_over_correct_th)
+
+            error_type = error["type"]
             if "threshold_unit" in error:
-                error["type"] = error["type"] + "_" + error["threshold_unit"]
-                
-            mAP_per_error_type[error["type"]] = np.mean(mAP_over_correct_ths)
+                error_type = error_type + "_" + error["threshold_unit"]
+
+            mAP_per_error_type[error_type] = np.mean(mAP_over_correct_ths)
             logger.info(
                 f"{error['type']}, Final mAP: {mAP_per_error_type[error['type']]:.3f}"
             )


### PR DESCRIPTION
eval_bop24_pose.by can evaluate several results in a row by passing comma separated `result_filenames`. However, current implementation crashes at the 2nd file because the error_type of the "mssd" error is overwritten to "mssd_mm".

Fix: use tmp variable