### PR TITLE
fixing missing bop24_mAP_mssd_mm (redundant with bop25_mAP_mm)

### DIFF
--- a/scripts/eval_bop24_pose.py
+++ b/scripts/eval_bop24_pose.py
@@ -264,7 +264,7 @@ for result_filename in result_filenames:
 
             mAP_per_error_type[error_type] = np.mean(mAP_over_correct_ths)
             logger.info(
-                f"{error['type']}, Final mAP: {mAP_per_error_type[error['type']]:.3f}"
+                f"{error_type}, Final mAP: {mAP_per_error_type[error_type]:.3f}"
             )
 
     time_total = time.time() - time_start
@@ -280,9 +280,10 @@ for result_filename in result_filenames:
     # Calculate the final scores.
     final_scores = {}
     for error in p["errors"]:
-        final_scores["bop24_mAP_{}".format(error["type"])] = mAP_per_error_type[
-            error["type"]
-        ]
+        error_type = error["type"]
+        if "threshold_unit" in error:
+            error_type = error_type + "_" + error["threshold_unit"]
+        final_scores[f"bop24_mAP_{error_type}"] = mAP_per_error_type[error_type]
 
     # Final score for the given dataset.
     final_scores["bop24_mAP"] = np.mean(


### PR DESCRIPTION
A bug was introduced in https://github.com/thodan/bop_toolkit/pull/209 that was resulting in [eval_bop24_pose](https://github.com/thodan/bop_toolkit/blob/master/scripts/eval_bop24_pose.py) outputting a `score_bop24.json` with a missing `bop24_mAP_mssd_mm` entry. This entry is actually redundant with `bop25_mAP_mm` as they both refer to the MSSD AP using absolute threshold (in millimeters). The `bop25_mAP_mm` is used to display in the leaderboard, hence this problem was only visible when looking at the sub_info pages.

This PR reintroduces the `bop24_mAP_mssd_mm` entry.